### PR TITLE
Update config.plist for DW1560

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -1019,6 +1019,42 @@
 				<key>PlistPath</key>
 				<string>Contents/Info.plist</string>
 			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>Any</string>
+				<key>BundlePath</key>
+				<string>AirportBrcmFixup.kext/Contents/PlugIns/AirPortBrcm4360_Injector.kext</string>
+				<key>Comment</key>
+				<string>SetMaxKernel</string>
+				<key>Enabled</key>
+				<true/>
+				<key>ExecutablePath</key>
+				<string></string>
+				<key>MaxKernel</key>
+				<string>19.9.9</string>
+				<key>MinKernel</key>
+				<string></string>
+				<key>PlistPath</key>
+				<string>Contents/Info.plist</string>
+			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>Any</string>
+				<key>BundlePath</key>
+				<string>AirportBrcmFixup.kext/Contents/PlugIns/AirPortBrcmNIC_Injector.kext</string>
+				<key>Comment</key>
+				<string></string>
+				<key>Enabled</key>
+				<true/>
+				<key>ExecutablePath</key>
+				<string></string>
+				<key>MaxKernel</key>
+				<string></string>
+				<key>MinKernel</key>
+				<string></string>
+				<key>PlistPath</key>
+				<string>Contents/Info.plist</string>
+			</dict>
 		</array>
 		<key>Block</key>
 		<array/>


### PR DESCRIPTION
I have an XPS 9560 that I have installed a DW1560 in and could not get the wireless card working. Looking at the bottom of the readme from [AirportBrcmFixup](https://github.com/acidanthera/AirportBrcmFixup), it says that the Max Kernel on AirPortBrcm4360_Injector.kext needs to be set to 19.9.9 for Big Sur using OpenCore. This setup is currently working for wifi and Bluetooth with my own testing. I do not have a DW1830 to test with like in your setup, but I do not think it should affect it.